### PR TITLE
Add Scan Alignment

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -30,3 +30,6 @@ install_manifest.txt
 compile_commands.json
 CTestTestfile.cmake
 _deps
+
+build/
+.cache/

--- a/bench/benchmark.cpp
+++ b/bench/benchmark.cpp
@@ -21,7 +21,7 @@ static std::string_view mode_to_string(mnem::scan_mode mode) {
     }
 }
 
-static void benchmark(mnem::scan_mode mode) {
+static void benchmark(mnem::scan_mode mode, mnem::scan_align align) {
     static constexpr size_t max_size = 0x40000000; // 1G, TODO a way to change this
 
     for (size_t size = 16; size <= max_size; size <<= 1) {
@@ -47,7 +47,7 @@ static void benchmark(mnem::scan_mode mode) {
 
             auto start = std::chrono::steady_clock::now();
             for (int j = 0; j < itersPerBuffer; j++)
-                [[maybe_unused]] auto _ = scanner.scan_signature(sig);
+                [[maybe_unused]] auto _ = scanner.scan_signature(sig, align);
             auto end = std::chrono::steady_clock::now();
 
             totalTime += std::chrono::duration_cast<std::chrono::microseconds>(end - start).count();
@@ -65,7 +65,7 @@ int main() {
     auto fastest_mode = mnem::detect_scan_mode();
     std::cout << "Highest supported mode: " << mode_to_string(fastest_mode) << '\n';
 
-    benchmark(mnem::scan_mode::avx2);
+    benchmark(mnem::scan_mode::normal, mnem::scan_align::x16);
 
     //for (int mode = static_cast<int>(mnem::scan_mode::normal); mode <= static_cast<int>(fastest_mode); mode++) {
     //    benchmark(static_cast<mnem::scan_mode>(mode));

--- a/bench/benchmark.cpp
+++ b/bench/benchmark.cpp
@@ -65,7 +65,7 @@ int main() {
     auto fastest_mode = mnem::detect_scan_mode();
     std::cout << "Highest supported mode: " << mode_to_string(fastest_mode) << '\n';
 
-    benchmark(mnem::scan_mode::normal, mnem::scan_align::x16);
+    benchmark(mnem::scan_mode::avx2, mnem::scan_align::x16);
 
     //for (int mode = static_cast<int>(mnem::scan_mode::normal); mode <= static_cast<int>(fastest_mode); mode++) {
     //    benchmark(static_cast<mnem::scan_mode>(mode));

--- a/include/mnemosyne/scan/scanner.hpp
+++ b/include/mnemosyne/scan/scanner.hpp
@@ -6,7 +6,6 @@
 #include "../core/memory_range.hpp"
 
 #include <algorithm>
-#include <execution>
 
 namespace mnem {
     // TODO: Execution policies to give the user better control over threading
@@ -40,14 +39,15 @@ namespace mnem {
     scan_mode detect_scan_mode();
 
     namespace internal {
-        const std::byte* do_scan(const std::byte* begin, const std::byte* end, signature sig, scan_mode mode);
+        const std::byte* do_scan(const std::byte* begin, const std::byte* end, signature sig, scan_mode mode, scan_align align);
 
-        inline std::byte* do_scan(std::byte* begin, std::byte* end, signature sig, scan_mode mode) {
+        inline std::byte* do_scan(std::byte* begin, std::byte* end, signature sig, scan_mode mode, scan_align align) {
             return const_cast<std::byte*>(do_scan( // rare const_cast use case?!?!?!
                     static_cast<const std::byte*>(begin),
                     static_cast<const std::byte*>(end),
                     sig,
-                    mode));
+                    mode,
+                    align));
         }
     }
 
@@ -56,7 +56,7 @@ namespace mnem {
     public:
         explicit scanner(Range range, scan_mode mode = detect_scan_mode()) noexcept : range_(std::move(range)), mode_(mode) {}
 
-        [[nodiscard]] memory_range_element_t<Range>* scan_signature(signature sig) const noexcept {
+        [[nodiscard]] memory_range_element_t<Range>* scan_signature(signature sig, scan_align align = scan_align::x1) const noexcept {
             if (sig.container().empty())
                 return nullptr;
 
@@ -64,7 +64,7 @@ namespace mnem {
                 if (std::distance(i.begin(), i.end()) < sig.size())
                     continue;
 
-                if (auto result = internal::do_scan(std::to_address(i.begin()), std::to_address(i.end()), sig, mode_); result)
+                if (auto result = internal::do_scan(std::to_address(i.begin()), std::to_address(i.end()), sig, mode_, align); result)
                     return result;
             }
 

--- a/include/mnemosyne/scan/scanner.hpp
+++ b/include/mnemosyne/scan/scanner.hpp
@@ -9,7 +9,6 @@
 
 namespace mnem {
     // TODO: Execution policies to give the user better control over threading
-    // TODO: Scan alignment for results we know are aligned in memory
     // TODO: Variants supporting multiple results and batches of signatures
     // TODO: Scan for scalar types and simple byte arrays
     // TODO: Result type instead of pointer

--- a/src/scan/scanner.cpp
+++ b/src/scan/scanner.cpp
@@ -2,7 +2,6 @@
 #include "../cpuid.hpp"
 
 #include <cstring>
-#include <execution>
 
 namespace mnem {
     scan_mode detect_scan_mode() {
@@ -91,7 +90,7 @@ namespace mnem::internal {
             return nullptr;
         }
 
-        auto iter = std::search(std::execution::unseq, begin, end, sig.begin(), sig.end());
+        auto iter = std::search(begin, end, sig.begin(), sig.end());
         return iter == end ? nullptr : iter;
     }
 

--- a/src/scan/scanner.cpp
+++ b/src/scan/scanner.cpp
@@ -2,14 +2,7 @@
 #include "../cpuid.hpp"
 
 #include <cstring>
-
-namespace {
-    auto find_byte(const std::byte* first, const std::byte* last, std::byte byte) {
-        // libstdc++'s std::find doesn't use memchr, unlike microsoft's implementation. Use memchr directly instead.
-        return reinterpret_cast<const std::byte*>(
-            std::memchr(first, static_cast<int>(byte), last - first));
-    }
-}
+#include <execution>
 
 namespace mnem {
     scan_mode detect_scan_mode() {
@@ -26,12 +19,59 @@ namespace mnem {
 }
 
 namespace mnem::internal {
-    const std::byte* scan_impl_normal(const std::byte* begin, const std::byte* end, signature sig) {
+    namespace {
+        auto find_byte(const std::byte* first, const std::byte* last, std::byte byte) {
+            // libstdc++'s std::find doesn't use memchr, unlike microsoft's implementation. Use memchr directly instead.
+            return reinterpret_cast<const std::byte*>(
+                std::memchr(first, static_cast<int>(byte), last - first));
+        }
+
+        const std::byte* do_scan_normal_x16(const std::byte* begin, const std::byte* end, signature sig) {
+            // Align begin to the next 16-byte boundary.
+            begin = reinterpret_cast<const std::byte*>(
+                (reinterpret_cast<uintptr_t>(begin) + 15) & ~static_cast<uintptr_t>(15));
+
+            // Make `end` the upper bound for where the first byte can be located.
+            end -= sig.size() - 1;
+
+            const auto first_elem = sig.front();
+            if (first_elem.mask() == std::byte{0xFF}) {
+                const auto first = first_elem.byte();
+
+                auto ptr = find_byte(begin, end, first);
+
+                while (ptr) [[likely]] {
+                    if (reinterpret_cast<uintptr_t>(ptr) % 16 == 0) [[unlikely]] {
+                        if (std::equal(sig.begin(), sig.end(), ptr)) [[unlikely]] {
+                            return ptr;
+                        }
+                    }
+
+                    ptr = find_byte(ptr + 1, end, first);
+                }
+
+                return nullptr;
+            }
+
+            for (auto ptr = begin; ptr < end; ptr += 16) {
+                if (std::equal(sig.begin(), sig.end(), ptr)) [[unlikely]] {
+                    return ptr;
+                }
+            }
+
+            return nullptr;
+        }
+    }
+
+    const std::byte* scan_impl_normal(const std::byte* begin, const std::byte* end, signature sig, scan_align align) {
         while (sig.back().mask() == std::byte{0}) {
             sig = sig.subsig(0, sig.size() - 1);
             end--;
             // the sig cannot be empty. like that LITERALLY cannot happen. that would be stupid. dumb even.
         }
+
+        if (align == scan_align::x16)
+            return do_scan_normal_x16(begin, end, sig);
 
         const auto first_elem = sig.front();
         if (first_elem.mask() == std::byte{0xFF}) {
@@ -55,25 +95,31 @@ namespace mnem::internal {
         return iter == end ? nullptr : iter;
     }
 
-    const std::byte* do_scan(const std::byte* begin, const std::byte* end, signature sig, scan_mode mode) {
-        // All scanners require this so we put it here.
-        // Right-strip is done by each individual scanner.
-        while (sig.front().mask() == std::byte{0}) {
-            sig = sig.subsig(1);
-            begin++;
-            if (sig.empty())
-                return (begin > end) ? nullptr : begin;
+    const std::byte* do_scan(const std::byte* begin, const std::byte* end, signature sig, scan_mode mode, scan_align align) {
+        // TODO: Cover this in a test because it broke scanning until now
+        size_t left_stripped = 0;
+        if (align == scan_align::x1) {
+            while (sig.front().mask() == std::byte{0}) {
+                left_stripped++;
+                sig = sig.subsig(1);
+                begin++;
+                if (sig.empty())
+                    return (begin > end) ? nullptr : begin;
+            }
         }
 
         if (begin >= end)
             return nullptr;
 
+        const std::byte* result;
         switch (mode) {
             case scan_mode::normal:
             default:
-                return scan_impl_normal(begin, end, sig);
+                result = scan_impl_normal(begin, end, sig, align);
             case scan_mode::avx2:
-                return scan_impl_avx2(begin, end, sig);
+                result = scan_impl_avx2(begin, end, sig, align);
         }
+
+        return result ? result - left_stripped : nullptr;
     }
 }

--- a/src/scan/scanner_avx2.cpp
+++ b/src/scan/scanner_avx2.cpp
@@ -237,7 +237,7 @@ namespace mnem::internal {
                 msig = _mm256_loadu_si256(reinterpret_cast<__m256i*>(std::to_address(masks.begin())));
             }
 
-            // FIXME: We also need to handle when the sig is smaller than register size...
+            // Since the comparison works differently from the x1 scanner, we don't need to worry if the sig is smaller than the register size.
             end -= sig.size() - 1;
 
             if (reinterpret_cast<uintptr_t>(begin) % 32) {
@@ -272,7 +272,7 @@ namespace mnem::internal {
                 if (mask & 0x00010000) {
                     if (ptr + 16 >= end)
                         return nullptr;
-                    
+
                     if constexpr (SigExt) {
                         if (std::equal(sig.begin() + 16, sig.end(), ptr + 32))
                             return ptr;

--- a/src/scan/scanner_avx2.cpp
+++ b/src/scan/scanner_avx2.cpp
@@ -1,6 +1,5 @@
 #include "scanner_impls.hpp"
 
-#include <iostream>
 #include <bit>
 
 #include <immintrin.h>
@@ -12,12 +11,6 @@ namespace mnem::internal {
             full,   // Fully unmasked
             masked  // Partially masked
         };
-
-        //enum class cmp_type {
-        //    none,       // Don't compare
-        //    vector,     // Do vectorized compare
-        //    extended,   // Do vectorized compare, then std::equal
-        //};
 
         // Find the optimal index in the two-byte search.
         size_t find_twobyte_idx(mnem::signature sig) {
@@ -215,11 +208,11 @@ namespace mnem::internal {
         }
     }
 
-    const std::byte* scan_impl_avx2(const std::byte* begin, const std::byte* end, signature sig) {
+    const std::byte* scan_impl_avx2(const std::byte* begin, const std::byte* end, signature sig, scan_align align) {
         auto twobyte_idx = find_twobyte_idx(sig);
 
         if (end - begin - twobyte_idx < 64) // pretty much not worth it if the buffer is that small
-            return scan_impl_normal(begin, end, sig);
+            return scan_impl_normal(begin, end, sig, align);
 
         // Strip bytes until they will fit into the AVX registers.
         while (sig.back().mask() == std::byte{0}) {

--- a/src/scan/scanner_impls.hpp
+++ b/src/scan/scanner_impls.hpp
@@ -15,6 +15,6 @@ namespace mnem::internal {
         return reinterpret_cast<T*>((reinterpret_cast<uintptr_t>(ptr) + ALIGN_MASK) & ~ALIGN_MASK);
     }
 
-    const std::byte* scan_impl_normal(const std::byte* begin, const std::byte* end, signature sig);
-    const std::byte* scan_impl_avx2(const std::byte* begin, const std::byte* end, signature sig);
+    const std::byte* scan_impl_normal(const std::byte* begin, const std::byte* end, signature sig, scan_align align);
+    const std::byte* scan_impl_avx2(const std::byte* begin, const std::byte* end, signature sig, scan_align align);
 }

--- a/src/scan/scanner_impls.hpp
+++ b/src/scan/scanner_impls.hpp
@@ -15,6 +15,9 @@ namespace mnem::internal {
         return reinterpret_cast<T*>((reinterpret_cast<uintptr_t>(ptr) + ALIGN_MASK) & ~ALIGN_MASK);
     }
 
-    const std::byte* scan_impl_normal(const std::byte* begin, const std::byte* end, signature sig, scan_align align);
-    const std::byte* scan_impl_avx2(const std::byte* begin, const std::byte* end, signature sig, scan_align align);
+    const std::byte* scan_impl_normal_x1(const std::byte* begin, const std::byte* end, signature sig);
+    const std::byte* scan_impl_normal_x16(const std::byte* begin, const std::byte* end, signature sig);
+
+    const std::byte* scan_impl_avx2_x1(const std::byte* begin, const std::byte* end, signature sig);
+    const std::byte* scan_impl_avx2_x16(const std::byte* begin, const std::byte* end, signature sig);
 }


### PR DESCRIPTION
This adds support for specifying the expected memory alignment of the scanner result. This is very useful when scanning for functions, since on x86, all functions are aligned to 16 bytes. The 16-byte-aligned AVX2 scanner is significantly faster than the unaligned AVX2 scanner, especially with small buffers.