### PR TITLE
Add object wrapper

### DIFF
--- a/.idea/vcs.xml
+++ b/.idea/vcs.xml
@@ -2,6 +2,5 @@
 <project version="4">
   <component name="VcsDirectoryMappings">
     <mapping directory="$PROJECT_DIR$" vcs="Git" />
-    <mapping directory="$PROJECT_DIR$/cmake-build-debug/_deps/googletest-src" vcs="Git" />
   </component>
 </project>

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -14,7 +14,8 @@ add_library(mnemosyne
         src/scan/scanner_impls.hpp
         src/scan/scanner_avx2.cpp
         src/cpuid.hpp
-        src/cpuid.cpp include/mnemosyne/defines.hpp include/mnemosyne/internal/abi/itanium/vfunc_index_impl.hpp include/mnemosyne/internal/abi/microsoft/vfunc_index_impl.hpp include/mnemosyne/core/vfunc_index.hpp)
+        src/cpuid.cpp include/mnemosyne/defines.hpp include/mnemosyne/internal/abi/itanium/vfunc_index_impl.hpp include/mnemosyne/internal/abi/microsoft/vfunc_index_impl.hpp include/mnemosyne/core/vfunc_index.hpp
+        include/mnemosyne/mem/wrapper.hpp)
 
 if ((CMAKE_CXX_COMPILER_ID STREQUAL "GNU") OR (CMAKE_CXX_COMPILER_ID STREQUAL "Clang"))
     set_source_files_properties(src/scan/scanner_avx2.cpp PROPERTIES COMPILE_FLAGS "-mavx -mavx2 -mbmi -mbmi2")

--- a/include/mnemosyne/mem/wrapper.hpp
+++ b/include/mnemosyne/mem/wrapper.hpp
@@ -11,6 +11,7 @@ namespace mnem {
     /// Tag used to prevent the initialization of a wrap<T> object.
     constexpr no_construct_t no_construct;
 
+    /// Provides a default destructor 
     template <class T>
     struct wrapper_default_destroy {
         static void destroy(T* obj) requires requires { obj->~T(); } {
@@ -118,6 +119,12 @@ namespace mnem {
     private:
         alignas(alignof(T)) std::byte buffer_[sizeof(T)]{};
     };
+
+    template <class T, class Traits = wrapper_traits<T>>
+    requires std::move_constructible<wrap<T, Traits>>
+    auto make_wrap(auto&&... args) {
+        return wrap<T, Traits>{ std::in_place, std::forward<decltype(args)>(args)... };
+    }
 }
 
 #endif

--- a/include/mnemosyne/mem/wrapper.hpp
+++ b/include/mnemosyne/mem/wrapper.hpp
@@ -1,0 +1,98 @@
+#pragma once
+#ifndef MNEMOSYNE_MEM_WRAPPER_HPP
+#define MNEMOSYNE_MEM_WRAPPER_HPP
+
+#include <algorithm>
+#include <cstddef>
+
+namespace mnem {
+    struct no_construct_t {};
+
+    /// Tag used to prevent the initialization of a wrap<T> object.
+    constexpr no_construct_t no_construct;
+
+    /// Controls the constructor behavior of wrap<T> objects.
+    template <class T>
+    struct wrapper_traits {
+        static void construct(std::byte* buffer, auto&&... args) {
+            new(buffer) T(std::forward<decltype(args)>(args)...);
+        }
+
+        static void destroy(T* obj) {
+            obj->~T();
+        }
+    };
+
+    /// General-purpose wrapper for using custom constructors/destructors.
+    /// Prevents devirtualization and gives control over constructors/destructors with the wrapper_traits class.
+    template <class T>
+    class wrap {
+    public:
+        explicit wrap(no_construct_t) {}
+
+        ~wrap() {
+            wrapper_traits<T>::destroy(this->get());
+        }
+
+        wrap() {
+            wrapper_traits<T>::construct(this->buffer());
+        }
+
+        wrap(const wrap<T>& copy) {
+            wrapper_traits<T>::construct(this->buffer(), *copy);
+        }
+
+        wrap(wrap<T>&& move) noexcept(false) {
+            wrapper_traits<T>::construct(this->buffer(), *std::move(move));
+        }
+
+        explicit wrap(std::in_place_t, auto&&... args) {
+            wrapper_traits<T>::construct(this->buffer(), std::forward<decltype(args)>(args)...);
+        }
+
+        [[nodiscard]] std::byte* buffer() {
+            return this->buffer_;
+        }
+
+        [[nodiscard]] const std::byte* buffer() const {
+            return this->buffer_;
+        }
+
+        [[nodiscard]] auto* get() {
+            return std::launder(reinterpret_cast<T*>(this->buffer_));
+        }
+
+        [[nodiscard]] auto* get() const {
+            return std::launder(reinterpret_cast<const T*>(this->buffer_));
+        }
+
+        [[nodiscard]] auto& operator*() & {
+            return *this->get();
+        }
+
+        [[nodiscard]] auto& operator*() const& {
+            return *this->get();
+        }
+
+        [[nodiscard]] auto&& operator*() && {
+            return std::move(*this->get());
+        }
+
+        [[nodiscard]] auto&& operator*() const&& {
+            return std::move(*this->get());
+        }
+
+        [[nodiscard]] T* operator->() {
+            return this->get();
+        }
+
+        [[nodiscard]] const T* operator->() const {
+            return this->get();
+        }
+
+    private:
+        alignas(alignof(T)) std::byte buffer_[sizeof(T)]{};
+    };
+}
+
+#endif

--- a/include/mnemosyne/mem/wrapper.hpp
+++ b/include/mnemosyne/mem/wrapper.hpp
@@ -11,21 +11,25 @@ namespace mnem {
     /// Tag used to prevent the initialization of a wrap<T> object.
     constexpr no_construct_t no_construct;
 
+    template <class T>
+    struct wrapper_default_destroy {
+        static void destroy(T* obj) requires requires { obj->~T(); } {
+            obj->~T();
+        }
+    };
+
     /// Controls the constructor behavior of wrap<T> objects.
     template <class T>
-    struct wrapper_traits {
-        static void construct(std::byte* buffer, auto&&... args) {
+    struct wrapper_traits : wrapper_default_destroy<T> {
+        static void construct(std::byte* buffer, auto&&... args) requires requires { new(buffer) T(std::forward<decltype(args)>(args)...); } {
             new(buffer) T(std::forward<decltype(args)>(args)...);
-        }
-
-        static void destroy(T* obj) {
-            obj->~T();
         }
     };
 
     /// General-purpose wrapper for using custom constructors/destructors.
     /// Prevents devirtualization and gives control over constructors/destructors with the wrapper_traits class.
     template <class T, class Traits = wrapper_traits<T>>
+    requires requires(T* obj) { Traits::destroy(obj); }
     class wrap {
     public:
         explicit wrap(no_construct_t) {}
@@ -34,25 +38,39 @@ namespace mnem {
             Traits::destroy(this->get());
         }
 
-        wrap() {
+        wrap() = delete;
+        wrap() requires requires(std::byte* buf) { Traits::construct(buf); } {
             Traits::construct(this->buffer());
         }
 
+        wrap(const wrap<T, Traits>&) = delete;
+        wrap(const wrap<T, Traits>& copy) requires requires(std::byte* buf, const T& obj) { Traits::construct(buf, obj); } {
+            Traits::construct(this->buffer(), *copy);
+        }
+
+        wrap(wrap<T, Traits>&&) = delete;
+        wrap(wrap<T, Traits>&& move) requires requires(std::byte* buf, T&& obj) { Traits::construct(buf, std::move(obj)); } {
+            Traits::construct(this->buffer(), *std::move(move));
+        }
+
         template <class Traits2>
+        requires requires(std::byte* buf, const T& obj) { Traits::construct(buf, obj); }
         wrap(const wrap<T, Traits2>& copy) {
             Traits::construct(this->buffer(), *copy);
         }
 
         template <class Traits2>
+        requires requires(std::byte* buf, T&& obj) { Traits::construct(buf, std::move(obj)); }
         wrap(wrap<T, Traits2>&& move) noexcept(false) {
             Traits::construct(this->buffer(), *std::move(move));
         }
 
-        explicit wrap(std::in_place_t, auto&&... args) {
+        explicit wrap(std::in_place_t, auto&&... args) requires requires { Traits::construct(this->buffer(), std::forward<decltype(args)>(args)...); } {
             Traits::construct(this->buffer(), std::forward<decltype(args)>(args)...);
         }
 
-        void reset(auto&&... args) {
+        /// Destroys the existing underlying value and constructs a new value in-place.
+        void emplace(auto&&... args) requires requires { Traits::construct(this->buffer(), std::forward<decltype(args)>(args)...); } {
             Traits::destroy(this->get());
             Traits::construct(this->buffer(), std::forward<decltype(args)>(args)...);
         }


### PR DESCRIPTION
This adds an object wrapper that allows for defining custom initialization code without allocating a buffer on the heap.